### PR TITLE
Add points tracking and ranking

### DIFF
--- a/app/(tabs)/community.tsx
+++ b/app/(tabs)/community.tsx
@@ -14,28 +14,29 @@ import { useAuthStore } from "@/store/auth-store";
 import { colors } from "@/constants/colors";
 import UserRankItem from "@/components/UserRankItem";
 import ReviewItem from "@/components/ReviewItem";
+import { User } from "@/types";
 
 export default function CommunityScreen() {
   const router = useRouter();
   const { user } = useAuthStore();
   const { reviews, getTopUsers } = useCommunityStore();
-  
-  const topUsers = getTopUsers(5);
-  const recentReviews = [...reviews].sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-  ).slice(0, 5);
-  
-  const getCurrentUserRank = () => {
+  const [topUsers, setTopUsers] = React.useState<User[]>([]);
+
+  React.useEffect(() => {
+    getTopUsers(5).then(setTopUsers);
+  }, []);
+  const recentReviews = [...reviews]
+    .sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    )
+    .slice(0, 5);
+
+  const currentUserRank = React.useMemo(() => {
     if (!user) return null;
-    
-    const allUsers = getTopUsers();
-    const userIndex = allUsers.findIndex(u => u.id === user.id);
-    
-    if (userIndex === -1) return null;
-    return userIndex + 1;
-  };
-  
-  const currentUserRank = getCurrentUserRank();
+    const idx = topUsers.findIndex((u) => u.id === user.id);
+    if (idx === -1) return null;
+    return idx + 1;
+  }, [topUsers, user]);
   
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
@@ -89,7 +90,7 @@ export default function CommunityScreen() {
           <Text style={styles.sectionTitle}>Clasificación</Text>
         </View>
         
-        <TouchableOpacity>
+        <TouchableOpacity onPress={() => router.push("/ranking")}>
           <Text style={styles.seeAllText}>Ver Todo</Text>
         </TouchableOpacity>
       </View>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -107,12 +107,19 @@ function RootLayoutNav() {
               headerShown: true
             }} 
           />
-          <Stack.Screen 
-            name="supplement/replenish" 
-            options={{ 
+          <Stack.Screen
+            name="supplement/replenish"
+            options={{
               title: "Reponer Suplemento",
               headerShown: true
-            }} 
+            }}
+          />
+          <Stack.Screen
+            name="ranking"
+            options={{
+              title: "Ranking",
+              headerShown: true
+            }}
           />
         </Stack>
       </QueryClientProvider>

--- a/app/ranking.tsx
+++ b/app/ranking.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from "react";
+import { View, Text, StyleSheet, ScrollView } from "react-native";
+import { usePointsStore } from "@/store/points-store";
+import { User } from "@/types";
+import UserRankItem from "@/components/UserRankItem";
+import { colors } from "@/constants/colors";
+
+export default function RankingScreen() {
+  const [users, setUsers] = useState<User[]>([]);
+  const getRanking = usePointsStore((s) => s.getRanking);
+
+  useEffect(() => {
+    getRanking().then(setUsers);
+  }, []);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.title}>Ranking</Text>
+      {users.map((u, idx) => (
+        <View key={u.id} style={styles.item}>
+          <UserRankItem user={{ ...u }} rank={idx + 1} />
+          {idx === 0 && <Text style={styles.badge}>🏆</Text>}
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  content: { padding: 16 },
+  title: {
+    fontSize: 24,
+    fontWeight: "bold",
+    color: colors.text,
+    marginBottom: 16,
+  },
+  item: { position: "relative" },
+  badge: {
+    position: "absolute",
+    right: 16,
+    top: 18,
+    fontSize: 20,
+  },
+});

--- a/store/community-store.ts
+++ b/store/community-store.ts
@@ -1,58 +1,64 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { Review } from "@/types";
-import { reviews, users } from "@/mocks/users";
+import { Review, User } from "@/types";
 import { useAuthStore } from "./auth-store";
+import { usePointsStore } from "./points-store";
+import {
+  collection,
+  addDoc,
+  getDocs,
+  query,
+  orderBy,
+  limit as limitDocs,
+} from "firebase/firestore";
+import { db } from "@/lib/firestore";
 
 interface CommunityState {
   reviews: Review[];
   isLoading: boolean;
   error: string | null;
-  
-  addReview: (supplementId: string, rating: number, comment: string) => void;
+
+  addReview: (supplementId: string, rating: number, comment: string) => Promise<void>;
   updateReview: (reviewId: string, rating: number, comment: string) => void;
   deleteReview: (reviewId: string) => void;
   getReviewsBySupplementId: (supplementId: string) => Review[];
   getReviewsByUserId: (userId: string) => Review[];
-  getTopUsers: (limit?: number) => typeof users;
+  getTopUsers: (limit?: number) => Promise<User[]>;
+  loadReviews: () => Promise<void>;
 }
 
 export const useCommunityStore = create<CommunityState>()(
   persist(
     (set, get) => ({
-      reviews: [...reviews],
+      reviews: [],
       isLoading: false,
       error: null,
-      
-      addReview: (supplementId, rating, comment) => {
+
+      addReview: async (supplementId, rating, comment) => {
         const user = useAuthStore.getState().user;
         if (!user) {
           set({ error: "Usuario no autenticado" });
           return;
         }
-        
-        const newReview: Review = {
-          id: String(get().reviews.length + 1),
+
+        const newReview: Omit<Review, "id"> = {
           userId: user.id,
           username: user.username,
           supplementId,
           rating,
           comment,
-          createdAt: new Date().toISOString()
+          createdAt: new Date().toISOString(),
         };
-        
-        set(state => ({
-          reviews: [...state.reviews, newReview]
+
+        const docRef = await addDoc(collection(db, "reviews"), newReview);
+
+        set((state) => ({
+          reviews: [...state.reviews, { ...newReview, id: docRef.id }],
         }));
-        
+
         // Añadir puntos por dejar una reseña
-        useAuthStore.setState({
-          user: {
-            ...user,
-            points: user.points + 10
-          }
-        });
+        await usePointsStore.getState().addPoints(10);
       },
       
       updateReview: (reviewId, rating, comment) => {
@@ -70,6 +76,12 @@ export const useCommunityStore = create<CommunityState>()(
           reviews: state.reviews.filter(review => review.id !== reviewId)
         }));
       },
+
+      loadReviews: async () => {
+        const snap = await getDocs(collection(db, "reviews"));
+        const data = snap.docs.map((d) => ({ ...(d.data() as Review), id: d.id }));
+        set({ reviews: data });
+      },
       
       getReviewsBySupplementId: (supplementId) => {
         return get().reviews.filter(review => review.supplementId === supplementId);
@@ -79,10 +91,14 @@ export const useCommunityStore = create<CommunityState>()(
         return get().reviews.filter(review => review.userId === userId);
       },
       
-      getTopUsers: (limit = 10) => {
-        return [...users]
-          .sort((a, b) => b.points - a.points)
-          .slice(0, limit);
+      getTopUsers: async (limit = 10) => {
+        const q = query(
+          collection(db, "users"),
+          orderBy("points", "desc"),
+          limitDocs(limit)
+        );
+        const snap = await getDocs(q);
+        return snap.docs.map((d) => ({ ...(d.data() as User), id: d.id }));
       }
     }),
     {

--- a/store/points-store.ts
+++ b/store/points-store.ts
@@ -1,0 +1,108 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useAuthStore } from "./auth-store";
+import { useSupplementStore } from "./supplement-store";
+import { db } from "@/lib/firestore";
+import {
+  doc,
+  setDoc,
+  updateDoc,
+  getDoc,
+  increment,
+  collectionGroup,
+  getDocs,
+  query,
+  orderBy,
+} from "firebase/firestore";
+import { User } from "@/types";
+
+function formatDate(date: Date) {
+  return date.toISOString().split("T")[0];
+}
+
+interface PointsState {
+  points: number;
+  lastAdherenceDate: string | null;
+  addPoints: (value: number) => Promise<void>;
+  processDailyAdherence: () => Promise<void>;
+  fetchPoints: () => Promise<void>;
+  getRanking: () => Promise<User[]>;
+}
+
+export const usePointsStore = create<PointsState>()(
+  persist(
+    (set, get) => ({
+      points: 0,
+      lastAdherenceDate: null,
+
+      addPoints: async (value) => {
+        const user = useAuthStore.getState().user;
+        if (!user) return;
+        const metaRef = doc(db, `users/${user.id}/meta`);
+        await setDoc(metaRef, { points: 0 }, { merge: true });
+        await updateDoc(metaRef, { points: increment(value) });
+        const metaSnap = await getDoc(metaRef);
+        const points = metaSnap.data()?.points || 0;
+        set({ points });
+        useAuthStore.getState().updateUser({ points });
+        await updateDoc(doc(db, "users", user.id), { points });
+      },
+
+      fetchPoints: async () => {
+        const user = useAuthStore.getState().user;
+        if (!user) return;
+        const metaRef = doc(db, `users/${user.id}/meta`);
+        const snap = await getDoc(metaRef);
+        const points = snap.exists() ? snap.data()?.points || 0 : 0;
+        set({ points });
+        useAuthStore.getState().updateUser({ points });
+      },
+
+      processDailyAdherence: async () => {
+        const user = useAuthStore.getState().user;
+        if (!user) return;
+        const today = formatDate(new Date());
+        if (get().lastAdherenceDate === today) return;
+
+        const { userSupplements } = useSupplementStore.getState();
+        const allTaken = userSupplements.every((s) => {
+          if (!s.days.includes(new Date().getDay())) return true;
+          return s.lastTakenAt?.some((t) => t.startsWith(today));
+        });
+        if (!allTaken) return;
+
+        await get().addPoints(10);
+        const yesterday = formatDate(new Date(Date.now() - 86400000));
+        const currentStreak =
+          get().lastAdherenceDate === yesterday ? (user.streak || 0) + 1 : 1;
+        useAuthStore.getState().updateUser({ streak: currentStreak });
+        await updateDoc(doc(db, "users", user.id), { streak: currentStreak });
+        if (currentStreak % 3 === 0) {
+          await get().addPoints(5);
+        }
+        set({ lastAdherenceDate: today });
+      },
+
+      getRanking: async () => {
+        const q = query(collectionGroup(db, "meta"), orderBy("points", "desc"));
+        const snap = await getDocs(q);
+        const result: User[] = [];
+        for (const d of snap.docs) {
+          const uid = d.ref.parent.parent?.id;
+          if (!uid) continue;
+          const userDoc = await getDoc(doc(db, "users", uid));
+          if (userDoc.exists()) {
+            result.push({ ...(userDoc.data() as User), id: uid, points: d.data().points || 0 });
+          }
+        }
+        result.sort((a, b) => b.points - a.points);
+        return result;
+      },
+    }),
+    {
+      name: "points-storage",
+      storage: createJSONStorage(() => AsyncStorage),
+    }
+  )
+);

--- a/types/index.ts
+++ b/types/index.ts
@@ -30,6 +30,7 @@ export type UserSupplement = {
   time: string;
   quantity: number;
   createdAt: string;
+  lastTakenAt?: string[];
 };
 
 export type Schedule = {


### PR DESCRIPTION
## Summary
- implement new `points-store` with Firestore integration
- extend `supplement-store` to track `lastTakenAt` and mark supplement intake
- persist user data to Firestore on login/register and sync points
- store community reviews in Firestore and compute top users from DB
- add ranking screen and route

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6859300427ac8329965638221a5965cc