### PR TITLE
Add catalog management with Firestore

### DIFF
--- a/app/(tabs)/discover.tsx
+++ b/app/(tabs)/discover.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import { colors } from '@/constants/colors';
 import Input from '@/components/Input';
 import Button from '@/components/Button';
 import { getSuggestedSupplements, getSuggestedSupplementsAI } from '@/lib/recommendation';
 import { RecommendedSupplement } from '@/types';
+import { useCatalogStore } from '@/store/catalog-store';
 import { useSupplementStore } from '@/store/supplement-store';
 
 export default function DiscoverScreen() {
@@ -13,13 +14,19 @@ export default function DiscoverScreen() {
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState('');
   const { addSupplement, userSupplements } = useSupplementStore();
+  const { catalog, subscribe } = useCatalogStore();
+
+  useEffect(() => {
+    const unsub = subscribe();
+    return unsub;
+  }, []);
 
   const handleSearch = async () => {
     setMessage('');
-    let list = getSuggestedSupplements(query);
+    let list = getSuggestedSupplements(catalog, query);
     if (list.length === 0) {
       setLoading(true);
-      list = await getSuggestedSupplementsAI(query);
+      list = await getSuggestedSupplementsAI(catalog, query);
       setLoading(false);
     }
     if (list.length === 0) {

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -137,7 +137,14 @@ export default function ProfileScreen() {
           <Award size={20} color={colors.primary} />
           <Text style={styles.menuItemText}>Logros</Text>
         </TouchableOpacity>
-        
+
+        {user?.id === 'admin-uid-placeholder' && (
+          <TouchableOpacity style={styles.menuItem} onPress={() => router.push('/admin-panel')}>
+            <Shield size={20} color={colors.primary} />
+            <Text style={styles.menuItemText}>Panel Admin</Text>
+          </TouchableOpacity>
+        )}
+
         <TouchableOpacity style={styles.menuItem}>
           <Shield size={20} color={colors.primary} />
           <Text style={styles.menuItemText}>Privacidad</Text>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -121,6 +121,13 @@ function RootLayoutNav() {
               headerShown: true
             }}
           />
+          <Stack.Screen
+            name="admin-panel"
+            options={{
+              title: "Admin",
+              headerShown: true
+            }}
+          />
         </Stack>
       </QueryClientProvider>
     </trpc.Provider>

--- a/app/admin-panel.tsx
+++ b/app/admin-panel.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/screens/AdminPanel';

--- a/lib/recommendation.ts
+++ b/lib/recommendation.ts
@@ -1,42 +1,25 @@
-import { supplements } from "@/mocks/supplements";
-import { RecommendedSupplement } from "@/types";
+import { RecommendedSupplement, CatalogSupplement } from "@/types";
 
-export function getSuggestedSupplements(input: string): RecommendedSupplement[] {
+export function getSuggestedSupplements(
+  catalog: CatalogSupplement[],
+  input: string
+): RecommendedSupplement[] {
   const text = input.toLowerCase();
-  const result: RecommendedSupplement[] = [];
-
-  const addSupps = (ids: string[], reason: string) => {
-    ids.forEach((id) => {
-      const sup = supplements.find((s) => s.id === id);
-      if (sup && !result.find((r) => r.id === id)) {
-        result.push({ ...sup, reason });
-      }
-    });
-  };
-
-  const map = [
-    { keywords: ["fatiga", "cansancio"], ids: ["3", "5", "7", "1"], reason: "Para combatir la fatiga" },
-    { keywords: ["estres", "estrés", "ansiedad"], ids: ["5", "3", "8"], reason: "Para reducir el estrés" },
-    { keywords: ["sue\u00f1o", "dormir"], ids: ["3", "5"], reason: "Para mejorar el sue\u00f1o" },
-    { keywords: ["energ\u00eda", "energia"], ids: ["7", "1", "6"], reason: "Para incrementar la energ\u00eda" },
-    { keywords: ["musculo", "muscular", "masa"], ids: ["6", "4"], reason: "Para ganar masa muscular" },
-    { keywords: ["inmunidad", "defensas"], ids: ["1", "4", "8"], reason: "Para reforzar la inmunidad" },
-    { keywords: ["digestion", "digestivo"], ids: ["8"], reason: "Para mejorar la digesti\u00f3n" },
-    { keywords: ["hormonal", "testosterona"], ids: ["5", "4"], reason: "Para equilibrio hormonal" },
-    { keywords: ["cardiovascular", "corazon"], ids: ["2"], reason: "Para salud cardiovascular" },
-    { keywords: ["concentracion", "concentraci\u00f3n"], ids: ["7", "6", "2"], reason: "Para mejorar la concentraci\u00f3n" },
-  ];
-
-  map.forEach((entry) => {
-    if (entry.keywords.some((k) => text.includes(k))) {
-      addSupps(entry.ids, entry.reason);
-    }
+  const matches = catalog.filter((c) => {
+    const inObjectives = c.objectives.some((o) => o.toLowerCase().includes(text));
+    return (
+      c.name.toLowerCase().includes(text) ||
+      c.description.toLowerCase().includes(text) ||
+      inObjectives
+    );
   });
-
-  return result;
+  return matches.map((m) => ({ ...m, reason: "Coincidencia con la búsqueda" }));
 }
 
-export async function getSuggestedSupplementsAI(input: string): Promise<RecommendedSupplement[]> {
+export async function getSuggestedSupplementsAI(
+  catalog: CatalogSupplement[],
+  input: string
+): Promise<RecommendedSupplement[]> {
   const apiKey = process.env.EXPO_PUBLIC_OPENAI_KEY || process.env.OPENAI_API_KEY;
   if (!apiKey) {
     return [];
@@ -73,7 +56,9 @@ export async function getSuggestedSupplementsAI(input: string): Promise<Recommen
   const result: RecommendedSupplement[] = [];
 
   parsed.forEach((item) => {
-    const sup = supplements.find((s) => s.name.toLowerCase() === String(item.name).toLowerCase());
+    const sup = catalog.find(
+      (s) => s.name.toLowerCase() === String(item.name).toLowerCase()
+    );
     if (sup && !result.find((r) => r.id === sup.id)) {
       result.push({ ...sup, reason: String(item.reason || "") });
     }

--- a/screens/AdminPanel.tsx
+++ b/screens/AdminPanel.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { useRouter } from 'expo-router';
+import { colors } from '@/constants/colors';
+import Input from '@/components/Input';
+import Button from '@/components/Button';
+import { useAuthStore } from '@/store/auth-store';
+import { useCatalogStore } from '@/store/catalog-store';
+import { CatalogSupplement } from '@/types';
+
+const ADMIN_UID = 'admin-uid-placeholder';
+
+export default function AdminPanel() {
+  const router = useRouter();
+  const { user } = useAuthStore();
+  const { catalog, subscribe, add, update, remove } = useCatalogStore();
+  const [editing, setEditing] = useState<CatalogSupplement | null>(null);
+  const [form, setForm] = useState<Omit<CatalogSupplement, 'id'>>({
+    name: '',
+    description: '',
+    type: '',
+    objectives: [],
+    priceEstimate: 0,
+    baseScore: 0,
+  });
+
+  useEffect(() => {
+    if (!user || user.id !== ADMIN_UID) {
+      router.replace('/');
+    }
+  }, [user]);
+
+  useEffect(() => {
+    const unsub = subscribe();
+    return unsub;
+  }, []);
+
+  const startNew = () => {
+    setEditing(null);
+    setForm({ name: '', description: '', type: '', objectives: [], priceEstimate: 0, baseScore: 0 });
+  };
+
+  const startEdit = (s: CatalogSupplement) => {
+    setEditing(s);
+    setForm({
+      name: s.name,
+      description: s.description,
+      type: s.type,
+      objectives: s.objectives,
+      priceEstimate: s.priceEstimate,
+      baseScore: s.baseScore,
+    });
+  };
+
+  const handleSave = async () => {
+    if (editing) {
+      await update(editing.id, { ...form });
+    } else {
+      await add(form);
+    }
+    startNew();
+  };
+
+  const handleDelete = async (id: string) => {
+    await remove(id);
+  };
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.title}>Catálogo de Suplementos</Text>
+      <Button title="Nuevo" onPress={startNew} style={styles.newBtn} />
+      {(editing || form.name) && (
+        <View style={styles.form}>
+          <Input label="Nombre" value={form.name} onChangeText={(t) => setForm({ ...form, name: t })} />
+          <Input label="Descripción" value={form.description} onChangeText={(t) => setForm({ ...form, description: t })} />
+          <Input label="Tipo" value={form.type} onChangeText={(t) => setForm({ ...form, type: t })} />
+          <Input label="Objetivos (coma separados)" value={form.objectives.join(',')} onChangeText={(t) => setForm({ ...form, objectives: t.split(',').map((v) => v.trim()).filter(Boolean) })} />
+          <Input label="Precio Estimado" value={String(form.priceEstimate)} keyboardType="numeric" onChangeText={(t) => setForm({ ...form, priceEstimate: parseFloat(t) || 0 })} />
+          <Input label="Base Score" value={String(form.baseScore)} keyboardType="numeric" onChangeText={(t) => setForm({ ...form, baseScore: parseFloat(t) || 0 })} />
+          <Button title="Guardar" onPress={handleSave} style={styles.saveBtn} />
+        </View>
+      )}
+      {catalog.map((c) => (
+        <View key={c.id} style={styles.item}>
+          <TouchableOpacity onPress={() => startEdit(c)}>
+            <Text style={styles.name}>{c.name}</Text>
+            <Text style={styles.desc}>{c.description}</Text>
+          </TouchableOpacity>
+          <View style={styles.actions}>
+            <Button title="Editar" onPress={() => startEdit(c)} size="small" style={styles.actionBtn} />
+            <Button title="Eliminar" onPress={() => handleDelete(c.id)} variant="danger" size="small" style={styles.actionBtn} />
+          </View>
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  content: { padding: 16 },
+  title: { fontSize: 24, fontWeight: 'bold', color: colors.text, marginBottom: 16 },
+  item: { backgroundColor: colors.card, padding: 12, borderRadius: 8, marginBottom: 12 },
+  name: { fontSize: 16, fontWeight: '600', color: colors.text },
+  desc: { fontSize: 14, color: colors.textSecondary },
+  actions: { flexDirection: 'row', marginTop: 8 },
+  actionBtn: { marginRight: 8 },
+  form: { marginBottom: 16 },
+  newBtn: { marginBottom: 16 },
+  saveBtn: { marginTop: 8 },
+});
+

--- a/store/catalog-store.ts
+++ b/store/catalog-store.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+import { CatalogSupplement } from '@/types';
+import { db } from '@/lib/firestore';
+import { collection, onSnapshot, addDoc, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+
+interface CatalogState {
+  catalog: CatalogSupplement[];
+  subscribe: () => () => void;
+  add: (data: Omit<CatalogSupplement, 'id'>) => Promise<void>;
+  update: (id: string, data: Partial<CatalogSupplement>) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+}
+
+export const useCatalogStore = create<CatalogState>((set) => ({
+  catalog: [],
+
+  subscribe: () => {
+    const ref = collection(db, 'catalog');
+    const unsub = onSnapshot(ref, (snap) => {
+      const list = snap.docs.map((d) => ({ ...(d.data() as Omit<CatalogSupplement, 'id'>), id: d.id }));
+      set({ catalog: list });
+    });
+    return unsub;
+  },
+
+  add: async (data) => {
+    await addDoc(collection(db, 'catalog'), data);
+  },
+
+  update: async (id, data) => {
+    await updateDoc(doc(db, 'catalog', id), data);
+  },
+
+  remove: async (id) => {
+    await deleteDoc(doc(db, 'catalog', id));
+  },
+}));

--- a/types/index.ts
+++ b/types/index.ts
@@ -23,6 +23,16 @@ export type Supplement = {
   reviewCount: number;
 };
 
+export type CatalogSupplement = {
+  id: string;
+  name: string;
+  description: string;
+  type: string;
+  objectives: string[];
+  priceEstimate: number;
+  baseScore: number; // 0-10
+};
+
 export type UserSupplement = {
   id: string;
   name: string;
@@ -70,4 +80,4 @@ export type Goal = {
   supplements: string[]; // Array de IDs de suplementos
 };
 
-export type RecommendedSupplement = Supplement & { reason: string };
+export type RecommendedSupplement = CatalogSupplement & { reason: string };


### PR DESCRIPTION
## Summary
- move supplement suggestions to Firestore catalog
- add catalog store and admin panel screen
- restrict admin panel to hardcoded UID
- update discover screen to load catalog
- show admin button in profile when user is admin
- register new route in root layout

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6859440689a88329ba8781880e9ead97