### PR TITLE
Add weekly supplement progress report

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -145,6 +145,13 @@ function RootLayoutNav() {
             }}
           />
           <Stack.Screen
+            name="resumen"
+            options={{
+              title: "Resumen",
+              headerShown: true
+            }}
+          />
+          <Stack.Screen
             name="admin-panel"
             options={{
               title: "Admin",

--- a/app/resumen.tsx
+++ b/app/resumen.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/screens/ResumenScreen';

--- a/lib/weeklyReport.ts
+++ b/lib/weeklyReport.ts
@@ -1,0 +1,86 @@
+import { collection, doc, getDocs, setDoc, query, where, orderBy, limit } from 'firebase/firestore';
+import { db } from './firestore';
+import { UserSupplement } from '@/types';
+
+export type WeeklyReport = {
+  startDate: string;
+  endDate: string;
+  totalScheduled: number;
+  totalTaken: number;
+  adherenceRate: number;
+  pointsGained: number;
+  worstSupplements: { id: string; name: string; adherence: number }[];
+};
+
+export async function generateWeeklyReport(uid: string): Promise<WeeklyReport> {
+  const end = new Date();
+  end.setHours(23, 59, 59, 999);
+  const start = new Date(end);
+  start.setDate(start.getDate() - 6);
+  start.setHours(0, 0, 0, 0);
+
+  const suppSnap = await getDocs(collection(db, `users/${uid}/supplements`));
+  const supplements = suppSnap.docs.map(d => ({ id: d.id, ...(d.data() as any) })) as UserSupplement[];
+
+  let totalScheduled = 0;
+  let totalTaken = 0;
+  const adherences: { id: string; name: string; adherence: number }[] = [];
+
+  for (const s of supplements) {
+    let scheduled = 0;
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(start);
+      d.setDate(start.getDate() + i);
+      if (s.days.includes(d.getDay())) scheduled++;
+    }
+    const taken = (s.lastTakenAt || []).filter(t => {
+      const ts = new Date(t);
+      return ts >= start && ts <= end;
+    }).length;
+
+    totalScheduled += scheduled;
+    totalTaken += Math.min(taken, scheduled);
+    const adherence = scheduled ? (taken / scheduled) * 100 : 100;
+    adherences.push({ id: s.id, name: s.name, adherence });
+  }
+
+  const pointsQ = query(
+    collection(db, `users/${uid}/pointsHistory`),
+    where('createdAt', '>=', start.toISOString()),
+    where('createdAt', '<=', end.toISOString())
+  );
+  const pointsSnap = await getDocs(pointsQ);
+  const pointsGained = pointsSnap.docs.reduce((sum, d) => sum + (d.data().value || 0), 0);
+
+  adherences.sort((a, b) => a.adherence - b.adherence);
+  const worstSupplements = adherences.filter(a => a.adherence < 100).slice(0, 3);
+
+  return {
+    startDate: start.toISOString().split('T')[0],
+    endDate: end.toISOString().split('T')[0],
+    totalScheduled,
+    totalTaken,
+    adherenceRate: totalScheduled ? (totalTaken / totalScheduled) * 100 : 0,
+    pointsGained,
+    worstSupplements,
+  };
+}
+
+export async function saveWeeklyReport(uid: string, report: WeeklyReport) {
+  await setDoc(doc(db, `users/${uid}/weeklyReports/${report.endDate}`), report);
+}
+
+export async function getLatestWeeklyReport(uid: string): Promise<WeeklyReport | null> {
+  const list = await getLastWeeklyReports(uid, 1);
+  return list[0] || null;
+}
+
+export async function getLastWeeklyReports(uid: string, count: number): Promise<WeeklyReport[]> {
+  const q = query(
+    collection(db, `users/${uid}/weeklyReports`),
+    orderBy('endDate', 'desc'),
+    limit(count)
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map(d => d.data() as WeeklyReport);
+}

--- a/screens/ResumenScreen.tsx
+++ b/screens/ResumenScreen.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { useAuthStore } from '@/store/auth-store';
+import AdherenceChart from '@/components/AdherenceChart';
+import { colors } from '@/constants/colors';
+import {
+  generateWeeklyReport,
+  saveWeeklyReport,
+  getLastWeeklyReports,
+  WeeklyReport,
+} from '@/lib/weeklyReport';
+
+export default function ResumenScreen() {
+  const { user } = useAuthStore();
+  const [report, setReport] = useState<WeeklyReport | null>(null);
+  const [previous, setPrevious] = useState<WeeklyReport | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      if (!user) return;
+      setLoading(true);
+      const reports = await getLastWeeklyReports(user.id, 2);
+      let latest = reports[0] || null;
+      let prev = reports[1] || null;
+
+      const now = new Date();
+      const diff = now.getDay();
+      const lastSunday = new Date(now);
+      lastSunday.setDate(now.getDate() - diff);
+      lastSunday.setHours(23, 59, 59, 999);
+      const lastEnd = lastSunday.toISOString().split('T')[0];
+
+      if (!latest || latest.endDate !== lastEnd) {
+        const newReport = await generateWeeklyReport(user.id);
+        await saveWeeklyReport(user.id, newReport);
+        prev = latest;
+        latest = newReport;
+      }
+
+      setReport(latest);
+      setPrevious(prev);
+      setLoading(false);
+    }
+    load();
+  }, [user]);
+
+  if (!user) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.message}>Inicia sesión para ver tu resumen.</Text>
+      </View>
+    );
+  }
+
+  if (loading) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.message}>Cargando...</Text>
+      </View>
+    );
+  }
+
+  if (!report) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.message}>
+          Aún no hay datos suficientes. ¡Empieza a registrar tus tomas!
+        </Text>
+      </View>
+    );
+  }
+
+  const improvement = previous
+    ? report.adherenceRate - previous.adherenceRate
+    : 0;
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.title}>Resumen Semanal</Text>
+
+      <AdherenceChart rate={report.adherenceRate} size="large" />
+      <Text style={styles.stat}>
+        Programadas: {report.totalScheduled}
+      </Text>
+      <Text style={styles.stat}>Tomadas: {report.totalTaken}</Text>
+      <Text style={styles.stat}>Puntos ganados: {report.pointsGained}</Text>
+
+      {improvement > 0 && (
+        <Text style={styles.highlight}>
+          ¡Mejoraste {improvement.toFixed(1)}% respecto a la semana anterior!
+        </Text>
+      )}
+
+      {report.worstSupplements.length > 0 && (
+        <View style={styles.worstSection}>
+          <Text style={styles.subtitle}>Suplementos con peor adherencia</Text>
+          {report.worstSupplements.map((s) => (
+            <Text key={s.id} style={styles.worstItem}>
+              {s.name} - {s.adherence.toFixed(0)}%
+            </Text>
+          ))}
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  content: { padding: 16, alignItems: 'center' },
+  title: { fontSize: 24, fontWeight: 'bold', color: colors.text, marginBottom: 16 },
+  stat: { fontSize: 16, color: colors.text, marginTop: 8 },
+  highlight: { fontSize: 16, color: colors.success, marginTop: 12, textAlign: 'center' },
+  message: { fontSize: 16, color: colors.text, textAlign: 'center', marginTop: 32 },
+  subtitle: { fontSize: 18, fontWeight: '600', color: colors.text, marginTop: 24 },
+  worstSection: { width: '100%', marginTop: 16 },
+  worstItem: { fontSize: 14, color: colors.textSecondary, marginTop: 4 },
+});

--- a/store/reviews-store.ts
+++ b/store/reviews-store.ts
@@ -60,7 +60,7 @@ export const useReviewsStore = create<ReviewsState>((set, get) => ({
         comment: data.comment,
         createdAt: new Date().toISOString(),
       });
-      await usePointsStore.getState().addPoints(10);
+      await usePointsStore.getState().addPoints(10, 'review');
     } else {
       const id = snap.docs[0].id;
       await updateDoc(doc(db, `supplements/${supplementId}/reviews/${id}`), {


### PR DESCRIPTION
## Summary
- log point events with reasons
- compute weekly supplement report and store in Firestore
- show weekly report in new Resumen screen
- register new route in layout

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68595270ec9483299ed0512925bc0b94