### PR TITLE
Add dotenv support for Expo Router

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_RORK_API_BASE_URL=https://api.falsa.com

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,11 @@
+import 'dotenv/config';
+
+export default ({ config }) => {
+  return {
+    ...config,
+    extra: {
+      ...config.extra,
+      EXPO_PUBLIC_RORK_API_BASE_URL: process.env.EXPO_PUBLIC_RORK_API_BASE_URL,
+    },
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@trpc/client": "^11.4.2",
         "@trpc/react-query": "^11.4.2",
         "@trpc/server": "^11.4.2",
+        "dotenv": "^16.5.0",
         "expo": "^53.0.4",
         "expo-blur": "~14.1.4",
         "expo-constants": "~17.1.4",
@@ -1748,6 +1749,18 @@
         "getenv": "^1.0.0"
       }
     },
+    "node_modules/@expo/env/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@expo/env/node_modules/getenv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-1.0.0.tgz",
@@ -1874,6 +1887,18 @@
         "minimatch": "^9.0.0",
         "postcss": "~8.4.32",
         "resolve-from": "^5.0.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@expo/metro-runtime": {
@@ -5560,9 +5585,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@trpc/client": "^11.4.2",
     "@trpc/react-query": "^11.4.2",
     "@trpc/server": "^11.4.2",
+    "dotenv": "^16.5.0",
     "expo": "^53.0.4",
     "expo-blur": "~14.1.4",
     "expo-constants": "~17.1.4",


### PR DESCRIPTION
## Summary
- add dotenv dependency
- create `.env` with EXPO_PUBLIC_RORK_API_BASE_URL
- setup Expo config in `app.config.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68596da54f948329abd91c9dca60837e