### PR TITLE
Handle push notifications in Expo Go

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,7 +3,7 @@ import { useFonts } from "expo-font";
 import { Stack, useRouter, useSegments } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
-import * as Notifications from "expo-notifications";
+import * as Notifications from "@/lib/notifications";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { trpc, trpcClient } from "@/lib/trpc";
@@ -48,6 +48,8 @@ export default function RootLayout() {
           await Notifications.requestPermissionsAsync();
         }
       }
+      // Attempt to register for push notifications if supported.
+      await Notifications.registerForPushNotificationsAsync();
     }
     requestPermission();
   }, []);

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -1,0 +1,59 @@
+import * as Notifications from "expo-notifications";
+import { isRunningInExpoGo } from "expo";
+
+let warned = false;
+
+/**
+ * Register for push notifications if running outside Expo Go.
+ * When running in Expo Go, this will warn the developer and resolve to null.
+ */
+export async function registerForPushNotificationsAsync() {
+  if (isRunningInExpoGo()) {
+    if (!warned) {
+      console.warn(
+        "Push notifications are not supported in Expo Go. Use a development build instead."
+      );
+      warned = true;
+    }
+    return null;
+  }
+
+  const { status } = await Notifications.getPermissionsAsync();
+  if (status !== "granted") {
+    const result = await Notifications.requestPermissionsAsync();
+    if (result.status !== "granted") {
+      return null;
+    }
+  }
+
+  try {
+    const token = await Notifications.getExpoPushTokenAsync();
+    return token;
+  } catch {
+    return null;
+  }
+}
+
+export function addPushNotificationReceivedListener(
+  listener: (event: Notifications.Notification) => void
+) {
+  if (isRunningInExpoGo()) {
+    if (__DEV__ && !warned) {
+      console.warn(
+        "Skipping push notification listener because app runs in Expo Go."
+      );
+      warned = true;
+    }
+    return { remove: () => {} } as Notifications.Subscription;
+  }
+
+  return Notifications.addNotificationReceivedListener(listener);
+}
+
+// Re-export commonly used local notification APIs
+export const {
+  scheduleNotificationAsync,
+  cancelScheduledNotificationAsync,
+  getPermissionsAsync,
+  requestPermissionsAsync,
+} = Notifications;

--- a/store/supplement-store.ts
+++ b/store/supplement-store.ts
@@ -12,7 +12,7 @@ import {
   updateDoc,
   arrayUnion,
 } from "firebase/firestore";
-import * as Notifications from "expo-notifications";
+import * as Notifications from "@/lib/notifications";
 import { db } from "@/lib/firestore";
 import { useAuthStore } from "./auth-store";
 import { usePointsStore } from "./points-store";


### PR DESCRIPTION
## Summary
- centralize expo-notifications usage in `lib/notifications.ts`
- register for push notifications only outside Expo Go
- warn when push registration or listeners are attempted in Expo Go
- use the wrapper across the app

## Testing
- `npx tsc -p .`

------
https://chatgpt.com/codex/tasks/task_e_68597b56cb508329849076f2386f917c