### PR TITLE
Use environment variable for admin uid

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET=tuBucket.appspot.com
 EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=1234567890
 EXPO_PUBLIC_FIREBASE_APP_ID=1:1234567890:web:abcdef
 EXPO_PUBLIC_OPENAI_KEY=sk-xxxx # o OPENAI_API_KEY
+EXPO_PUBLIC_ADMIN_UID=tuUidDeAdmin
 ```
+
+`EXPO_PUBLIC_ADMIN_UID` debe contener el UID de Firebase del usuario que tendrá acceso al panel de administración.
 
 ### Backend (Hono + tRPC)
 

--- a/screens/AdminPanel.tsx
+++ b/screens/AdminPanel.tsx
@@ -8,7 +8,7 @@ import { useAuthStore } from '@/store/auth-store';
 import { useCatalogStore } from '@/store/catalog-store';
 import { CatalogSupplement } from '@/types';
 
-const ADMIN_UID = 'admin-uid-placeholder';
+const ADMIN_UID = process.env.EXPO_PUBLIC_ADMIN_UID ?? 'admin-uid-placeholder';
 
 export default function AdminPanel() {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- use `EXPO_PUBLIC_ADMIN_UID` in AdminPanel
- document new variable

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6861912f403483298ee5071c9f512365