### PR TITLE
Handle OpenAI API failure

### DIFF
--- a/lib/recommendation.ts
+++ b/lib/recommendation.ts
@@ -27,21 +27,33 @@ export async function getSuggestedSupplementsAI(
 
   const prompt = `Devuelve una lista JSON con los suplementos m\u00e1s recomendados para el siguiente s\u00edntoma u objetivo: ${input}`;
 
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      model: "gpt-3.5-turbo",
-      messages: [
-        { role: "system", content: "Eres un asistente experto en suplementos" },
-        { role: "user", content: prompt },
-      ],
-      temperature: 0.7,
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [
+          { role: "system", content: "Eres un asistente experto en suplementos" },
+          { role: "user", content: prompt },
+        ],
+        temperature: 0.7,
+      }),
+    });
+    if (!response.ok) {
+      console.warn(
+        `OpenAI API request failed with status ${response.status}`
+      );
+      return getSuggestedSupplements(catalog, input);
+    }
+  } catch (err) {
+    console.warn("OpenAI API request failed", err);
+    return getSuggestedSupplements(catalog, input);
+  }
 
   const data = await response.json();
   const text = data.choices?.[0]?.message?.content || "[]";


### PR DESCRIPTION
## Summary
- catch OpenAI fetch errors
- warn when requests fail and return local suggestions as fallback

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6861984f58e08329aae7942f68a8c3ae